### PR TITLE
Empty CUDA cache before profiling

### DIFF
--- a/pytorch_memlab/line_profiler.py
+++ b/pytorch_memlab/line_profiler.py
@@ -78,6 +78,7 @@ class LineProfiler:
             self.register_callback()
 
     def __enter__(self):
+        torch.cuda.empty_cache()
         self.enable()
 
     def __exit__(self, exc_type, exc_val, exc_tb):


### PR DESCRIPTION
Why:
* If you have previously run some code you wish to profile with
  different parameters, causing it to allocate more memory, then this
  will lead to inaccurate profiling results which correspond to the set
  of parameters that cause the maximum memory usage due to torch's CUDA
  memory allocator.

This change addresses the need by:
* Emptying the CUDA memory cache before profiling resolves this issue.