### PR TITLE
Catch RuntimeError in torch.cuda.reset_peak_memory_stats

### DIFF
--- a/pytorch_memlab/line_profiler/line_profiler.py
+++ b/pytorch_memlab/line_profiler/line_profiler.py
@@ -88,8 +88,9 @@ class LineProfiler:
         try:
             torch.cuda.empty_cache()
             self._reset_cuda_stats()
-        # Pytorch-1.7.0 raises AttributeError while <1.6.0 raises AssertionError
-        except (AssertionError, AttributeError) as error:
+        # What error is raised depends on PyTorch version:
+        # latest raises RuntimeError, 1.7.0 raises AttributeError, <1.7.0 raises AssertionError
+        except (AssertionError, AttributeError, RuntimeError) as error:
             print('Could not reset CUDA stats and cache: ' + str(error))
 
         self.register_callback()


### PR DESCRIPTION
The AttributeError was fixed in https://github.com/pytorch/pytorch/pull/48406