### PR TITLE
Avoid Styler.hide_index and render duplicated in Pandas 1.4

### DIFF
--- a/pytorch_memlab/line_profiler/line_records.py
+++ b/pytorch_memlab/line_profiler/line_records.py
@@ -222,8 +222,8 @@ class RecordsDisplay:
                                 .set_table_styles([{
                                     'selector': 'th',
                                     'props': [('text-align', 'left')]}])
-                                .hide_index()
-                                .render())
+                                .hide(axis=0)
+                                .to_html())
 
         template = '<h3><span style="font-family: monospace">{q}</span></h3><div>{c}</div>'
         return '\n'.join(template.format(q=q, c=c) for q, c in html.items())


### PR DESCRIPTION
Hi, thank you for this package. I found another issue with the latest Pandas (see https://pandas.pydata.org/docs/whatsnew/v1.4.0.html#styler for detail)