### PR TITLE
Skip dead weakrefs during tensor collection

### DIFF
--- a/pytorch_memlab/mem_reporter.py
+++ b/pytorch_memlab/mem_reporter.py
@@ -79,7 +79,13 @@ class MemReporter():
         if self.pre_collect:
             gc.collect()
         objects = gc.get_objects()
-        tensors = [obj for obj in objects if isinstance(obj, torch.Tensor)]
+        tensors = []
+        for obj in objects:
+            try:
+                if isinstance(obj, torch.Tensor):
+                    tensors.append(obj)
+            except ReferenceError:
+                continue
         for t in tensors:
             self.device_mapping[t.device].append(t)
 

--- a/test/test_mem_reporter.py
+++ b/test/test_mem_reporter.py
@@ -1,3 +1,5 @@
+import weakref
+
 import torch
 import torch.optim
 from pytorch_memlab import MemReporter
@@ -22,6 +24,23 @@ def test_readable_size_with_symbolic_byte_size(monkeypatch):
     monkeypatch.setattr('pytorch_memlab.utils.calmsize', lambda num_bytes: SymbolicSize())
 
     assert readable_size(object()) == '4M<ByteSize amount=s0>'
+
+def test_reporter_ignores_dead_weakrefs(monkeypatch):
+    class WeakrefTarget:
+        pass
+
+    target = WeakrefTarget()
+    dead_proxy = weakref.proxy(target)
+    del target
+
+    tensor = torch.empty(1)
+    monkeypatch.setattr(
+        'pytorch_memlab.mem_reporter.gc.get_objects',
+        lambda: [dead_proxy, tensor],
+    )
+
+    reporter = MemReporter()
+    reporter.report()
 
 def test_reporter():
     linear = torch.nn.Linear(1024, 1024)


### PR DESCRIPTION
## Summary
- skip objects that raise ReferenceError while MemReporter scans gc.get_objects()
- add a regression test covering dead weakref proxies during report()

Fixes #40.

## Tests
- pytest test/test_mem_reporter.py
- python -c 'import pytorch_memlab'